### PR TITLE
feat: add scale-down-cooldown stabilization window

### DIFF
--- a/cmd/fly-autoscaler/main.go
+++ b/cmd/fly-autoscaler/main.go
@@ -129,6 +129,7 @@ type Config struct {
 	Concurrency            int           `yaml:"concurrency"`
 	Interval               time.Duration `yaml:"interval"`
 	Timeout                time.Duration `yaml:"timeout"`
+	ScaleDownCooldown      time.Duration `yaml:"scale-down-cooldown"`
 	AppListRefreshInterval time.Duration `yaml:"app-list-refresh-interval"`
 	APIToken               string        `yaml:"api-token"`
 	Verbose                bool          `yaml:"verbose"`
@@ -185,6 +186,11 @@ func NewConfigFromEnv() (_ *Config, err error) {
 	if s := os.Getenv("FAS_TIMEOUT"); s != "" {
 		if c.Timeout, err = time.ParseDuration(s); err != nil {
 			return nil, fmt.Errorf("cannot parse FAS_TIMEOUT as duration: %q", s)
+		}
+	}
+	if s := os.Getenv("FAS_SCALE_DOWN_COOLDOWN"); s != "" {
+		if c.ScaleDownCooldown, err = time.ParseDuration(s); err != nil {
+			return nil, fmt.Errorf("cannot parse FAS_SCALE_DOWN_COOLDOWN as duration: %q", s)
 		}
 	}
 	if s := os.Getenv("FAS_APP_LIST_REFRESH_INTERVAL"); s != "" {

--- a/cmd/fly-autoscaler/serve.go
+++ b/cmd/fly-autoscaler/serve.go
@@ -78,6 +78,7 @@ func (c *ServeCommand) Run(ctx context.Context, args []string) (err error) {
 		r.InitialMachineState = c.Config.InitialMachineState
 		r.Regions = c.Config.Regions
 		r.ProcessGroup = c.Config.ProcessGroup
+		r.ScaleDownCooldown = c.Config.ScaleDownCooldown
 		r.Collectors = collectors
 		return r
 	}
@@ -92,6 +93,7 @@ func (c *ServeCommand) Run(ctx context.Context, args []string) (err error) {
 	attrs := []any{
 		slog.String("interval", p.ReconcileInterval.String()),
 		slog.String("timeout", p.ReconcileTimeout.String()),
+		slog.String("scaleDownCooldown", c.Config.ScaleDownCooldown.String()),
 		slog.String("appListRefreshInterval", p.AppListRefreshInterval.String()),
 		slog.Int("collectors", len(collectors)),
 	}

--- a/reconciler.go
+++ b/reconciler.go
@@ -58,8 +58,13 @@ type Reconciler struct {
 	// scale-down stabilization window. Appended to on every reconcile that
 	// successfully computed a max value; pruned to entries within
 	// ScaleDownCooldown.
+	//
+	// Keyed by AppName so a single Reconciler reused across apps (wildcard
+	// pool mode) keeps each app's cooldown window independent. Without this,
+	// app A's high peak would suppress scale-down for an unrelated app B that
+	// happens to share the worker.
 	targetHistoryMu sync.Mutex
-	targetHistory   []targetSample
+	targetHistory   map[string][]targetSample
 
 	// Injectable clock for tests. nil means use time.Now.
 	NowFunc func() time.Time
@@ -92,7 +97,9 @@ func (r *Reconciler) now() time.Time {
 }
 
 // recordTargetSample appends the current raw max targets to the rolling
-// history window and trims any entries older than ScaleDownCooldown.
+// history window for r.AppName and trims any entries older than
+// ScaleDownCooldown. History is per-app because a single Reconciler is
+// reused across apps in wildcard pool mode.
 func (r *Reconciler) recordTargetSample(maxCreated, maxStarted int) {
 	if r.ScaleDownCooldown <= 0 {
 		return
@@ -103,24 +110,32 @@ func (r *Reconciler) recordTargetSample(maxCreated, maxStarted int) {
 	r.targetHistoryMu.Lock()
 	defer r.targetHistoryMu.Unlock()
 
-	r.targetHistory = append(r.targetHistory, targetSample{t: now, maxCreated: maxCreated, maxStarted: maxStarted})
+	if r.targetHistory == nil {
+		r.targetHistory = make(map[string][]targetSample)
+	}
+	samples := append(r.targetHistory[r.AppName], targetSample{t: now, maxCreated: maxCreated, maxStarted: maxStarted})
 
 	// Drop samples older than the window.
 	i := 0
-	for ; i < len(r.targetHistory); i++ {
-		if !r.targetHistory[i].t.Before(cutoff) {
+	for ; i < len(samples); i++ {
+		if !samples[i].t.Before(cutoff) {
 			break
 		}
 	}
 	if i > 0 {
-		r.targetHistory = append(r.targetHistory[:0], r.targetHistory[i:]...)
+		samples = append(samples[:0], samples[i:]...)
+	}
+	if len(samples) == 0 {
+		delete(r.targetHistory, r.AppName)
+	} else {
+		r.targetHistory[r.AppName] = samples
 	}
 }
 
-// peakWindow returns the highest maxCreated and maxStarted observed within
-// the cooldown window, and the age of the oldest sample still in the window.
-// If the window is empty (or cooldown is disabled), it returns the raw inputs
-// and zero age.
+// peakWindow returns the highest maxCreated and maxStarted observed for
+// r.AppName within the cooldown window, and the age of the oldest sample
+// still in the window. If the window is empty (or cooldown is disabled), it
+// returns the raw inputs and zero age.
 func (r *Reconciler) peakWindow(rawMaxCreated, rawMaxStarted int) (int, int, time.Duration) {
 	if r.ScaleDownCooldown <= 0 {
 		return rawMaxCreated, rawMaxStarted, 0
@@ -131,7 +146,7 @@ func (r *Reconciler) peakWindow(rawMaxCreated, rawMaxStarted int) (int, int, tim
 
 	peakCreated, peakStarted := rawMaxCreated, rawMaxStarted
 	var oldest time.Time
-	for _, s := range r.targetHistory {
+	for _, s := range r.targetHistory[r.AppName] {
 		if s.maxCreated > peakCreated {
 			peakCreated = s.maxCreated
 		}

--- a/reconciler.go
+++ b/reconciler.go
@@ -6,7 +6,9 @@ import (
 	"log/slog"
 	"math"
 	"sort"
+	"sync"
 	"sync/atomic"
+	"time"
 
 	"github.com/expr-lang/expr"
 	"github.com/superfly/fly-go"
@@ -46,6 +48,22 @@ type Reconciler struct {
 	// Initial machine state (started or stopped)
 	InitialMachineState string
 
+	// Stabilization window for scale-down. When set, downscale actions
+	// (destroy/stop) only fire if the raw target has stayed below the current
+	// machine count for this entire duration. Scale-up is unaffected.
+	// Zero disables the window and restores pre-cooldown behavior.
+	ScaleDownCooldown time.Duration
+
+	// targetHistory holds recent raw max-target samples used to implement the
+	// scale-down stabilization window. Appended to on every reconcile that
+	// successfully computed a max value; pruned to entries within
+	// ScaleDownCooldown.
+	targetHistoryMu sync.Mutex
+	targetHistory   []targetSample
+
+	// Injectable clock for tests. nil means use time.Now.
+	NowFunc func() time.Time
+
 	// List of collectors to fetch metric values from.
 	Collectors []MetricCollector
 
@@ -53,11 +71,83 @@ type Reconciler struct {
 	Stats *ReconcilerStats
 }
 
+type targetSample struct {
+	t          time.Time
+	maxCreated int
+	maxStarted int
+}
+
 func NewReconciler() *Reconciler {
 	return &Reconciler{
 		metrics: make(map[string]float64),
 		Stats:   &ReconcilerStats{},
 	}
+}
+
+func (r *Reconciler) now() time.Time {
+	if r.NowFunc != nil {
+		return r.NowFunc()
+	}
+	return time.Now()
+}
+
+// recordTargetSample appends the current raw max targets to the rolling
+// history window and trims any entries older than ScaleDownCooldown.
+func (r *Reconciler) recordTargetSample(maxCreated, maxStarted int) {
+	if r.ScaleDownCooldown <= 0 {
+		return
+	}
+	now := r.now()
+	cutoff := now.Add(-r.ScaleDownCooldown)
+
+	r.targetHistoryMu.Lock()
+	defer r.targetHistoryMu.Unlock()
+
+	r.targetHistory = append(r.targetHistory, targetSample{t: now, maxCreated: maxCreated, maxStarted: maxStarted})
+
+	// Drop samples older than the window.
+	i := 0
+	for ; i < len(r.targetHistory); i++ {
+		if !r.targetHistory[i].t.Before(cutoff) {
+			break
+		}
+	}
+	if i > 0 {
+		r.targetHistory = append(r.targetHistory[:0], r.targetHistory[i:]...)
+	}
+}
+
+// peakWindow returns the highest maxCreated and maxStarted observed within
+// the cooldown window, and the age of the oldest sample still in the window.
+// If the window is empty (or cooldown is disabled), it returns the raw inputs
+// and zero age.
+func (r *Reconciler) peakWindow(rawMaxCreated, rawMaxStarted int) (int, int, time.Duration) {
+	if r.ScaleDownCooldown <= 0 {
+		return rawMaxCreated, rawMaxStarted, 0
+	}
+
+	r.targetHistoryMu.Lock()
+	defer r.targetHistoryMu.Unlock()
+
+	peakCreated, peakStarted := rawMaxCreated, rawMaxStarted
+	var oldest time.Time
+	for _, s := range r.targetHistory {
+		if s.maxCreated > peakCreated {
+			peakCreated = s.maxCreated
+		}
+		if s.maxStarted > peakStarted {
+			peakStarted = s.maxStarted
+		}
+		if oldest.IsZero() || s.t.Before(oldest) {
+			oldest = s.t
+		}
+	}
+
+	var age time.Duration
+	if !oldest.IsZero() {
+		age = r.now().Sub(oldest)
+	}
+	return peakCreated, peakStarted, age
 }
 
 // NextRegion returns the next region to launch a machine in.
@@ -168,6 +258,15 @@ func (r *Reconciler) Reconcile(ctx context.Context) error {
 
 	slog.Info("reconciling", logAttrs...)
 
+	// Record the raw max targets into the rolling stabilization window and
+	// compute the stabilized (peak-held) values used only for scale-down
+	// decisions. Scale-up paths below continue to use the raw min/max values
+	// so upscaling remains immediate.
+	if hasMaxCreatedN || hasMaxStartedN {
+		r.recordTargetSample(maxCreatedN, maxStartedN)
+	}
+	stabilizedMaxCreatedN, stabilizedMaxStartedN, windowAge := r.peakWindow(maxCreatedN, maxStartedN)
+
 	// Determine if we need to create or destroy machines.
 	createdN := len(filtered)
 	if hasMinCreatedN && createdN < minCreatedN {
@@ -180,8 +279,18 @@ func (r *Reconciler) Reconcile(ctx context.Context) error {
 		config.Image = machine.FullImageRef()
 		return r.createN(ctx, filtered[0].Config, machine.Region, minCreatedN-createdN)
 	}
-	if hasMaxCreatedN && createdN > maxCreatedN {
-		return r.destroyN(ctx, m, createdN-maxCreatedN)
+	if hasMaxCreatedN && createdN > stabilizedMaxCreatedN {
+		return r.destroyN(ctx, m, createdN-stabilizedMaxCreatedN)
+	}
+	if hasMaxCreatedN && createdN > maxCreatedN && r.ScaleDownCooldown > 0 {
+		slog.Info("scale-down deferred by cooldown",
+			slog.String("app", r.AppName),
+			slog.String("kind", "destroy"),
+			slog.Int("current", createdN),
+			slog.Int("raw_max", maxCreatedN),
+			slog.Int("stabilized_max", stabilizedMaxCreatedN),
+			slog.Duration("cooldown_remaining", r.ScaleDownCooldown-windowAge),
+		)
 	}
 
 	// Determine if we need to start/stop machines.
@@ -189,8 +298,18 @@ func (r *Reconciler) Reconcile(ctx context.Context) error {
 	if hasMinStartedN && startedN < minStartedN {
 		return r.startN(ctx, m[fly.MachineStateStopped], minStartedN-startedN)
 	}
-	if hasMaxStartedN && startedN > maxStartedN {
-		return r.stopN(ctx, m[fly.MachineStateStarted], startedN-maxStartedN)
+	if hasMaxStartedN && startedN > stabilizedMaxStartedN {
+		return r.stopN(ctx, m[fly.MachineStateStarted], startedN-stabilizedMaxStartedN)
+	}
+	if hasMaxStartedN && startedN > maxStartedN && r.ScaleDownCooldown > 0 {
+		slog.Info("scale-down deferred by cooldown",
+			slog.String("app", r.AppName),
+			slog.String("kind", "stop"),
+			slog.Int("current", startedN),
+			slog.Int("raw_max", maxStartedN),
+			slog.Int("stabilized_max", stabilizedMaxStartedN),
+			slog.Duration("cooldown_remaining", r.ScaleDownCooldown-windowAge),
+		)
 	}
 
 	r.Stats.NoScale.Add(1)

--- a/reconciler_test.go
+++ b/reconciler_test.go
@@ -631,3 +631,53 @@ func TestReconciler_ScaleDownCooldown(t *testing.T) {
 		t.Fatalf("expected immediate scale-up despite cooldown, got created=%d", created)
 	}
 }
+
+// In wildcard pool mode the same Reconciler is reused across apps, with
+// AppName rotated per work-queue item. Each app must keep its own cooldown
+// history; otherwise app A's recent peak can suppress app B's downscale.
+func TestReconciler_ScaleDownCooldown_MultiAppIsolation(t *testing.T) {
+	cooldown := 5 * time.Minute
+
+	machineConfig := &fly.MachineConfig{}
+	// Both apps report 4 started machines.
+	listFour := func(ctx context.Context, state string) ([]*fly.Machine, error) {
+		return []*fly.Machine{
+			{ID: "1", State: fly.MachineStateStarted, Region: "iad", HostStatus: fly.HostStatusOk, Config: machineConfig},
+			{ID: "2", State: fly.MachineStateStarted, Region: "iad", HostStatus: fly.HostStatusOk, Config: machineConfig},
+			{ID: "3", State: fly.MachineStateStarted, Region: "iad", HostStatus: fly.HostStatusOk, Config: machineConfig},
+			{ID: "4", State: fly.MachineStateStarted, Region: "iad", HostStatus: fly.HostStatusOk, Config: machineConfig},
+		}, nil
+	}
+
+	var client mock.FlapsClient
+	var destroyedB int
+	client.ListFunc = listFour
+	client.DestroyFunc = func(ctx context.Context, input fly.RemoveMachineInput, nonce string) error {
+		destroyedB++
+		return nil
+	}
+
+	now := time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC)
+	r := fas.NewReconciler()
+	r.Client = &client
+	r.ScaleDownCooldown = cooldown
+	r.NowFunc = func() time.Time { return now }
+
+	// App A reconciles with high demand → seeds its own history with peak=4.
+	r.AppName = "app-a"
+	r.MinCreatedMachineN, r.MaxCreatedMachineN = "0", "4"
+	if err := r.Reconcile(context.Background()); err != nil {
+		t.Fatal(err)
+	}
+
+	// App B reconciles with low demand and a fleet of 4 → would-destroy 2.
+	// App A's peak must NOT defer App B's destroy.
+	r.AppName = "app-b"
+	r.MinCreatedMachineN, r.MaxCreatedMachineN = "0", "2"
+	if err := r.Reconcile(context.Background()); err != nil {
+		t.Fatal(err)
+	}
+	if destroyedB != 2 {
+		t.Fatalf("expected app-b destroys to fire independently of app-a peak, got destroyedB=%d", destroyedB)
+	}
+}

--- a/reconciler_test.go
+++ b/reconciler_test.go
@@ -7,6 +7,7 @@ import (
 	"math"
 	"os"
 	"testing"
+	"time"
 
 	fas "github.com/superfly/fly-autoscaler"
 	"github.com/superfly/fly-autoscaler/mock"
@@ -543,4 +544,90 @@ func machineCountByState(a []*fly.Machine, state string) (n int) {
 		}
 	}
 	return n
+}
+
+// Exercise the scale-down stabilization window: with a non-zero
+// ScaleDownCooldown, a downscale is deferred until the high watermark in the
+// window has aged out. Scale-up is unaffected.
+func TestReconciler_ScaleDownCooldown(t *testing.T) {
+	cooldown := 5 * time.Minute
+
+	// We simulate 4 created "app" machines. Target max starts at 4 (no
+	// scale-down), then drops to 2 (would destroy 2). Within cooldown, the
+	// destroy must be skipped. After the clock advances past cooldown, it
+	// must fire.
+	machineConfig := &fly.MachineConfig{}
+	listMachines := func() ([]*fly.Machine, error) {
+		return []*fly.Machine{
+			{ID: "1", State: fly.MachineStateStarted, Region: "iad", HostStatus: fly.HostStatusOk, Config: machineConfig},
+			{ID: "2", State: fly.MachineStateStarted, Region: "iad", HostStatus: fly.HostStatusOk, Config: machineConfig},
+			{ID: "3", State: fly.MachineStateStarted, Region: "iad", HostStatus: fly.HostStatusOk, Config: machineConfig},
+			{ID: "4", State: fly.MachineStateStarted, Region: "iad", HostStatus: fly.HostStatusOk, Config: machineConfig},
+		}, nil
+	}
+
+	var client mock.FlapsClient
+	var destroyed int
+	client.ListFunc = func(ctx context.Context, state string) ([]*fly.Machine, error) { return listMachines() }
+	client.DestroyFunc = func(ctx context.Context, input fly.RemoveMachineInput, nonce string) error {
+		destroyed++
+		return nil
+	}
+
+	now := time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC)
+	r := fas.NewReconciler()
+	r.Client = &client
+	r.ScaleDownCooldown = cooldown
+	r.NowFunc = func() time.Time { return now }
+
+	// First reconcile: target matches current; sample the high watermark.
+	r.MinCreatedMachineN, r.MaxCreatedMachineN = "0", "4"
+	if err := r.Reconcile(context.Background()); err != nil {
+		t.Fatal(err)
+	}
+	if destroyed != 0 {
+		t.Fatalf("expected no destroys on first reconcile, got %d", destroyed)
+	}
+
+	// Second reconcile, 1 minute later: demand drops, but the t=0 sample with
+	// maxCreated=4 is still in the 5m window → stabilizedMax=4 ≥ current=4,
+	// so no destroy.
+	now = now.Add(1 * time.Minute)
+	r.MinCreatedMachineN, r.MaxCreatedMachineN = "0", "2"
+	if err := r.Reconcile(context.Background()); err != nil {
+		t.Fatal(err)
+	}
+	if destroyed != 0 {
+		t.Fatalf("expected destroy to be deferred within cooldown, got destroyed=%d", destroyed)
+	}
+
+	// Advance past the cooldown window. All prior samples age out, so the
+	// peak collapses to the latest raw max=2 and destroys fire.
+	now = now.Add(cooldown + 1*time.Second)
+	r.MinCreatedMachineN, r.MaxCreatedMachineN = "0", "2"
+	if err := r.Reconcile(context.Background()); err != nil {
+		t.Fatal(err)
+	}
+	if destroyed != 2 {
+		t.Fatalf("expected 2 destroys after cooldown expired, got %d", destroyed)
+	}
+
+	// And scale-up remains immediate even with cooldown set: bump max back
+	// up to 5 and confirm a create fires without waiting.
+	// Reset destroy counter (already asserted) and stub Launch.
+	var created int
+	client.LaunchFunc = func(ctx context.Context, input fly.LaunchMachineInput) (*fly.Machine, error) {
+		created++
+		return &fly.Machine{ID: fmt.Sprintf("new-%d", created), Region: input.Region}, nil
+	}
+	// At this point the fleet still has 4 machines per listMachines; push
+	// target up to 5 to force a create.
+	now = now.Add(10 * time.Second)
+	r.MinCreatedMachineN, r.MaxCreatedMachineN = "5", "5"
+	if err := r.Reconcile(context.Background()); err != nil {
+		t.Fatal(err)
+	}
+	if created == 0 {
+		t.Fatalf("expected immediate scale-up despite cooldown, got created=%d", created)
+	}
 }


### PR DESCRIPTION
## Summary

Adds a `scale-down-cooldown` config option (and `FAS_SCALE_DOWN_COOLDOWN` env var) that defers downscale actions until the raw target has stayed below the current machine count for the full cooldown window. Scale-up paths are unchanged — upscaling stays immediate.

Implements the long-standing upstream request in superfly/fly-autoscaler#15 ("Throttling"), modeled on Kubernetes HPA's scale-down stabilization window.

## Why

Without a cooldown, the reconciler recomputes the target every `interval` (30s here) and immediately calls `destroyN` / `stopN` whenever the metric dips. With bursty workloads (BullMQ job queues here), this causes constant create/destroy churn — visible as a sawtooth oscillation between baseline and peak in active-worker dashboards.

## How

- Each reconcile records the raw `maxCreatedN` / `maxStartedN` into an in-memory `targetHistory` ring on the `Reconciler`.
- Entries older than `ScaleDownCooldown` are pruned.
- For scale-down decisions only, `stabilizedMax = max(rawMax, peakInWindow)` is used instead of the raw value.
- Default is `0` (disabled — pre-cooldown behavior preserved).

When a scale-down is suppressed by the window, an `slog.Info` line is emitted with `cooldown_remaining` so operators can see the deferral in `fly logs`.

## Test plan

- [x] New `TestReconciler_ScaleDownCooldown` drives the reconciler across the cooldown boundary using an injectable `NowFunc` clock and verifies:
  - destroy is suppressed within the window when the raw target drops
  - destroy fires after the window elapses
  - scale-up is still immediate even while cooldown is configured
- [x] Existing `go test ./...` continues to pass